### PR TITLE
Fixed visibility toggling of a horizontal or vertical panel

### DIFF
--- a/BlazorSliders.sln
+++ b/BlazorSliders.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.10.35004.147
+# Visual Studio Version 18
+VisualStudioVersion = 18.0.11222.15 d18.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlazorSliders", "BlazorSliders\BlazorSliders.csproj", "{A98EA7D0-4693-46E9-B264-57CD58473DE4}"
 EndProject

--- a/BlazorSliders/HorizontalSliderPanel.razor.cs
+++ b/BlazorSliders/HorizontalSliderPanel.razor.cs
@@ -8,7 +8,7 @@ using Microsoft.JSInterop;
 
 namespace BlazorSliders
 {
-    public partial class HorizontalSliderPanel : SliderPanelBase
+    public partial class HorizontalSliderPanel : SliderPanelBase, IDisposable
     {
         public SliderPanelBase TopPanel { get; set; }
         public SliderPanelBase BottomPanel { get; set; }
@@ -17,6 +17,7 @@ namespace BlazorSliders
         private int originalTopPanelHeight;
 
         string topPanelId = "";
+
         public string TopPanelId
         {
             get
@@ -25,11 +26,13 @@ namespace BlazorSliders
                 {
                     topPanelId = NewGuid();
                 }
+
                 return topPanelId;
             }
         }
 
         string bottomPanelId = "";
+
         public string BottomPanelId
         {
             get
@@ -38,50 +41,38 @@ namespace BlazorSliders
                 {
                     bottomPanelId = NewGuid();
                 }
+
                 return bottomPanelId;
             }
         }
 
-		[Parameter]
-        public RenderFragment TopHeaderContent { get; set; }
+        [Parameter] public RenderFragment TopHeaderContent { get; set; }
 
-		[Parameter]
-        public RenderFragment TopChildContent { get; set; }
+        [Parameter] public RenderFragment TopChildContent { get; set; }
 
-        [Parameter]
-        public RenderFragment BottomHeaderContent { get; set; }
+        [Parameter] public RenderFragment BottomHeaderContent { get; set; }
 
-        [Parameter]
-        public RenderFragment BottomChildContent { get; set; }
+        [Parameter] public RenderFragment BottomChildContent { get; set; }
 
-		[Parameter]
-		public RenderFragment SliderContent { get; set; }
+        [Parameter] public RenderFragment SliderContent { get; set; }
 
-		[Parameter]
-        public string TopStyleString { get; set; } = "";
+        [Parameter] public string TopStyleString { get; set; } = "";
 
-        [Parameter]
-        public string TopClassString { get; set; } = "";
+        [Parameter] public string TopClassString { get; set; } = "";
 
-        [Parameter]
-        public string BottomStyleString { get; set; } = "";
+        [Parameter] public string BottomStyleString { get; set; } = "";
 
-        [Parameter]
-        public string BottomClassString { get; set; } = "";
+        [Parameter] public string BottomClassString { get; set; } = "";
 
-        [Parameter]
-        public int SliderHeight { get; set; } = 5;
+        [Parameter] public int SliderHeight { get; set; } = 5;
 
-        [Parameter]
-        public string SliderClassString { get; set; } = "";
+        [Parameter] public string SliderClassString { get; set; } = "";
 
-        [Parameter]
-        public bool OverrideSliderStyle { get; set; }
+        [Parameter] public bool OverrideSliderStyle { get; set; }
 
         public string DefaultSliderClass { get; set; }
 
-        [Parameter]
-        public SizeUnit HeightUnit { get; set; }
+        [Parameter] public SizeUnit HeightUnit { get; set; }
 
         [Parameter]
         public int TopPanelHeight
@@ -111,27 +102,38 @@ namespace BlazorSliders
             }
         }
 
-        [Parameter]
-        public int MinimumTopPanelHeight { get; set; } = 200;
+        [Parameter] public int MinimumTopPanelHeight { get; set; } = 200;
 
-        [Parameter]
-        public int MinimumBottomPanelHeight { get; set; } = 200;
+        [Parameter] public int MinimumBottomPanelHeight { get; set; } = 200;
 
-        [Parameter]
-        public int InitialSliderPosition { get; set; }
+        [Parameter] public int InitialSliderPosition { get; set; }
 
         /// <summary>
         /// Gets the current slider position. Use this property to read the current position value.
         /// </summary>
         public int CurrentSliderPosition => topPanelHeight;
 
-        [Parameter]
-        public EventCallback<int> SliderPositionChanged { get; set; }
+        [Parameter] public EventCallback<int> SliderPositionChanged { get; set; }
 
-        protected string TopPanelHeightPx { get { return topPanelHeight.ToString() + "px"; } }
-        protected string BottomPanelHeightPx { get { return BottomPanelHeight.ToString() + "px"; } }
-        protected string BottomPanelTopPx { get { return (topPanelHeight + SliderHeight).ToString() + "px"; } }
-        protected string SliderHeightPx { get { return SliderHeight.ToString() + "px"; } }
+        protected string TopPanelHeightPx
+        {
+            get { return topPanelHeight.ToString() + "px"; }
+        }
+
+        protected string BottomPanelHeightPx
+        {
+            get { return BottomPanelHeight.ToString() + "px"; }
+        }
+
+        protected string BottomPanelTopPx
+        {
+            get { return (topPanelHeight + SliderHeight).ToString() + "px"; }
+        }
+
+        protected string SliderHeightPx
+        {
+            get { return SliderHeight.ToString() + "px"; }
+        }
 
         public int BottomPanelHeight
         {
@@ -165,6 +167,7 @@ namespace BlazorSliders
             {
                 await SliderPositionChanged.InvokeAsync(topPanelHeight);
             }
+
             await InvokeAsync(StateHasChanged);
         }
 
@@ -215,6 +218,36 @@ namespace BlazorSliders
                 topPanelHeight = InitialSliderPosition;
                 if (originalTopPanelHeight <= 0)
                     originalTopPanelHeight = InitialSliderPosition;
+            }
+        }
+
+        public void Dispose()
+        {
+            // Clean up parent references when this panel is destroyed
+            if (Parent != null)
+            {
+                if (Parent.GetType() == typeof(VerticalSliderPanel))
+                {
+                    var parent = (VerticalSliderPanel)Parent;
+                    if (parent.LeftPanel == this)
+                        parent.LeftPanel = null;
+                    if (parent.RightPanel == this)
+                        parent.RightPanel = null;
+                }
+                else if (Parent.GetType() == typeof(HorizontalSliderPanel))
+                {
+                    var parent = (HorizontalSliderPanel)Parent;
+                    if (parent.TopPanel == this)
+                        parent.TopPanel = null;
+                    if (parent.BottomPanel == this)
+                        parent.BottomPanel = null;
+                }
+                else if (Parent.GetType() == typeof(AbsolutePanel))
+                {
+                    var parent = (AbsolutePanel)Parent;
+                    if (parent.ChildPanel == this)
+                        parent.ChildPanel = null;
+                }
             }
         }
     }

--- a/BlazorSliders/VerticalSliderPanel.razor.cs
+++ b/BlazorSliders/VerticalSliderPanel.razor.cs
@@ -8,7 +8,7 @@ using Microsoft.JSInterop;
 
 namespace BlazorSliders
 {
-    public partial class VerticalSliderPanel : SliderPanelBase
+    public partial class VerticalSliderPanel : SliderPanelBase, IDisposable
     {
         public SliderPanelBase LeftPanel { get; set; }
 
@@ -29,6 +29,7 @@ namespace BlazorSliders
         }
 
         string rightPanelId = "";
+
         public string RightPanelId
         {
             get
@@ -40,37 +41,27 @@ namespace BlazorSliders
 
         }
 
-        [Parameter]
-        public RenderFragment LeftChildContent { get; set; }
+        [Parameter] public RenderFragment LeftChildContent { get; set; }
 
-        [Parameter]
-        public RenderFragment RightChildContent { get; set; }
+        [Parameter] public RenderFragment RightChildContent { get; set; }
 
-        [Parameter]
-        public string LeftStyleString { get; set; } = "";
+        [Parameter] public string LeftStyleString { get; set; } = "";
 
-        [Parameter]
-        public string LeftClassString { get; set; } = "";
+        [Parameter] public string LeftClassString { get; set; } = "";
 
-        [Parameter]
-        public string RightStyleString { get; set; } = "";
+        [Parameter] public string RightStyleString { get; set; } = "";
 
-        [Parameter]
-        public string RightClassString { get; set; } = "";
+        [Parameter] public string RightClassString { get; set; } = "";
 
-        [Parameter]
-        public int SliderWidth { get; set; } = 5;
+        [Parameter] public int SliderWidth { get; set; } = 5;
 
-        [Parameter]
-        public string SliderClassString { get; set; } = "";
+        [Parameter] public string SliderClassString { get; set; } = "";
 
-        [Parameter]
-        public bool OverrideSliderStyle { get; set; }
+        [Parameter] public bool OverrideSliderStyle { get; set; }
 
         public string DefaultSliderClass { get; set; }
 
-        [Parameter]
-        public SizeUnit WidthUnit { get; set; }
+        [Parameter] public SizeUnit WidthUnit { get; set; }
 
         [Parameter]
         public int LeftPanelStartingWidth
@@ -100,16 +91,16 @@ namespace BlazorSliders
             }
         }
 
-        public int LeftPanelWidth { get => leftPanelWidth; }
+        public int LeftPanelWidth
+        {
+            get => leftPanelWidth;
+        }
 
-        [Parameter]
-        public int MinimumLeftPanelWidth { get; set; } = 200;
+        [Parameter] public int MinimumLeftPanelWidth { get; set; } = 200;
 
-        [Parameter]
-        public int MinimumRightPanelWidth { get; set; } = 200;
+        [Parameter] public int MinimumRightPanelWidth { get; set; } = 200;
 
-        [Parameter]
-        public int InitialSliderPosition { get; set; }
+        [Parameter] public int InitialSliderPosition { get; set; }
 
         /// <summary>
         /// Gets the current slider position. Use this property to read the current position value.
@@ -130,16 +121,30 @@ namespace BlazorSliders
             }
         }
 
-        [Parameter]
-        public EventCallback<int> SliderPositionChanged { get; set; }
+        [Parameter] public EventCallback<int> SliderPositionChanged { get; set; }
 
-        protected string LeftPanelWidthPx { get { return leftPanelWidth.ToString() + "px"; } }
-        protected string RightPanelWidthPx { get { return RightPanelWidth.ToString() + "px"; } }
-        protected string RightPanelLeftPx { get { return (leftPanelWidth + SliderWidth).ToString() + "px"; } }
-        protected string SliderWidthPx { get { return SliderWidth.ToString() + "px"; } }
+        protected string LeftPanelWidthPx
+        {
+            get { return leftPanelWidth.ToString() + "px"; }
+        }
+
+        protected string RightPanelWidthPx
+        {
+            get { return RightPanelWidth.ToString() + "px"; }
+        }
+
+        protected string RightPanelLeftPx
+        {
+            get { return (leftPanelWidth + SliderWidth).ToString() + "px"; }
+        }
+
+        protected string SliderWidthPx
+        {
+            get { return SliderWidth.ToString() + "px"; }
+        }
 
 
-        
+
         public int RightPanelWidth
         {
             get
@@ -173,6 +178,7 @@ namespace BlazorSliders
             {
                 await SliderPositionChanged.InvokeAsync(leftPanelWidth);
             }
+
             await InvokeAsync(StateHasChanged);
         }
 
@@ -220,6 +226,36 @@ namespace BlazorSliders
                 leftPanelWidth = InitialSliderPosition;
                 if (originalLeftPanelWidth <= 0)
                     originalLeftPanelWidth = InitialSliderPosition;
+            }
+        }
+
+        public void Dispose()
+        {
+            // Clean up parent references when this panel is destroyed
+            if (Parent != null)
+            {
+                if (Parent.GetType() == typeof(VerticalSliderPanel))
+                {
+                    var parent = (VerticalSliderPanel)Parent;
+                    if (parent.LeftPanel == this)
+                        parent.LeftPanel = null;
+                    if (parent.RightPanel == this)
+                        parent.RightPanel = null;
+                }
+                else if (Parent.GetType() == typeof(HorizontalSliderPanel))
+                {
+                    var parent = (HorizontalSliderPanel)Parent;
+                    if (parent.TopPanel == this)
+                        parent.TopPanel = null;
+                    if (parent.BottomPanel == this)
+                        parent.BottomPanel = null;
+                }
+                else if (Parent.GetType() == typeof(AbsolutePanel))
+                {
+                    var parent = (AbsolutePanel)Parent;
+                    if (parent.ChildPanel == this)
+                        parent.ChildPanel = null;
+                }
             }
         }
     }

--- a/BlazorSlidersServerTestApp/Components/Pages/NavMenu.razor
+++ b/BlazorSlidersServerTestApp/Components/Pages/NavMenu.razor
@@ -29,4 +29,7 @@
     <NavLink class="nav-link" href="goldenratio">
         <span class="oi oi-resize-both" aria-hidden="true"></span> Golden Ratio
     </NavLink>
+    <NavLink class="nav-link" href="visibility">
+        <span class="oi oi-resize-both" aria-hidden="true"></span> Visibility
+    </NavLink>
 </div>

--- a/BlazorSlidersServerTestApp/Components/Pages/Visibility.razor
+++ b/BlazorSlidersServerTestApp/Components/Pages/Visibility.razor
@@ -1,0 +1,97 @@
+﻿@page "/visibility"
+<div style="display: flex; flex-direction: column; height: 100vh; width: 100vw; background-color: #0a0a0a;">
+    <div style="padding: 10px; background-color: #252526; color: white; display: flex; justify-content: space-between; align-items: center; flex-shrink: 0; z-index: 100;">
+        <h3 style="margin: 0;">BlazorSliders Test Page</h3>
+        <button @onclick="ToggleBottomPanel" style="padding: 8px 16px; background-color: #0e639c; color: white; border: none; border-radius: 4px; cursor: pointer; font-size: 14px;">
+            @(_showBottomPanel ? "Hide" : "Show") Bottom Panel
+        </button>
+    </div>
+
+    <div style="flex: 1; overflow: hidden; position: relative;">
+        <AbsolutePanel AutoResize="true">
+            <VerticalSliderPanel LeftPanelStartingWidth="300"
+                                 MinimumLeftPanelWidth="200"
+                                 MinimumRightPanelWidth="400">
+                <LeftChildContent>
+                    <div style="height: 100%; width: 100%; background-color: #ff4444; padding: 20px; overflow: auto; box-sizing: border-box;">
+                        <h2 style="color: white;">Left Panel (Red)</h2>
+                        <p style="color: white;">This should be visible with red background</p>
+                        @for (int i = 1; i <= 50; i++)
+                        {
+                            <p style="color: white;">Line @i</p>
+                        }
+                    </div>
+                </LeftChildContent>
+                <RightChildContent>
+                    <VerticalSliderPanel PanelPosition="PanelPosition.Right"
+                                         LeftPanelStartingWidth="800"
+                                         MinimumLeftPanelWidth="400"
+                                         MinimumRightPanelWidth="280">
+                        <LeftChildContent>
+                            <div style="height: 100%; width: 100%;">
+                                @if (_showBottomPanel)
+                                {
+                                    <HorizontalSliderPanel @key="@("horizontal-split")"
+                                                           PanelPosition="PanelPosition.Left"
+                                                           TopPanelHeight="300">
+                                        <TopChildContent>
+                                            <div style="height: 100%; width: 100%; background-color: #44ff44; padding: 20px; overflow: auto; box-sizing: border-box;">
+                                                <h2 style="color: black;">Top Panel (Green)</h2>
+                                                <p style="color: black;">This should be visible with green background</p>
+                                                @for (int i = 1; i <= 50; i++)
+                                                {
+                                                    <p style="color: black;">Top Line @i</p>
+                                                }
+                                            </div>
+                                        </TopChildContent>
+                                        <BottomChildContent>
+                                            <div style="height: 100%; width: 100%; background-color: #ff44ff; padding: 20px; overflow: auto; box-sizing: border-box;">
+                                                <h2 style="color: white;">Bottom Panel (Magenta)</h2>
+                                                <p style="color: white;">This should be visible with magenta background</p>
+                                                @for (int i = 1; i <= 50; i++)
+                                                {
+                                                    <p style="color: white;">Bottom Line @i</p>
+                                                }
+                                            </div>
+                                        </BottomChildContent>
+                                    </HorizontalSliderPanel>
+                                }
+                                else
+                                {
+                                    <div @key="@("single-panel")" style="height: 100%; width: 100%; background-color: #44ff44; padding: 20px; overflow: auto; box-sizing: border-box;">
+                                        <h2 style="color: black;">Center Panel (Green)</h2>
+                                        <p style="color: black;">This should be visible with green background - Bottom panel hidden</p>
+                                        @for (int i = 1; i <= 50; i++)
+                                        {
+                                            <p style="color: black;">Line @i</p>
+                                        }
+                                    </div>
+                                }
+                            </div>
+                        </LeftChildContent>
+                        <RightChildContent>
+                            <div style="height: 100%; width: 100%; background-color: #4444ff; padding: 20px; overflow: auto; box-sizing: border-box;">
+                                <h2 style="color: white;">Right Panel (Blue)</h2>
+                                <p style="color: white;">This should be visible with blue background</p>
+                                @for (int i = 1; i <= 50; i++)
+                                {
+                                    <p style="color: white;">Right Line @i</p>
+                                }
+                            </div>
+                        </RightChildContent>
+                    </VerticalSliderPanel>
+                </RightChildContent>
+            </VerticalSliderPanel>
+        </AbsolutePanel>
+    </div>
+</div>
+
+@code {
+    private bool _showBottomPanel = true;
+
+    private async Task ToggleBottomPanel()
+    {
+        _showBottomPanel = !_showBottomPanel;
+        await InvokeAsync(StateHasChanged);
+    }
+}

--- a/BlazorSlidersWasmTestApp/Pages/NavMenu.razor
+++ b/BlazorSlidersWasmTestApp/Pages/NavMenu.razor
@@ -38,4 +38,7 @@
     <NavLink class="nav-link" href="partialheaders">
         <span class="oi oi-resize-height" aria-hidden="true"></span> Partial Headers
     </NavLink>
+    <NavLink class="nav-link" href="visibility">
+        <span class="oi oi-resize-both" aria-hidden="true"></span> Visibility
+    </NavLink>
 </div>

--- a/BlazorSlidersWasmTestApp/Pages/Visibility.razor
+++ b/BlazorSlidersWasmTestApp/Pages/Visibility.razor
@@ -1,0 +1,97 @@
+﻿@page "/visibility"
+<div style="display: flex; flex-direction: column; height: 100vh; width: 100vw; background-color: #0a0a0a;">
+    <div style="padding: 10px; background-color: #252526; color: white; display: flex; justify-content: space-between; align-items: center; flex-shrink: 0; z-index: 100;">
+        <h3 style="margin: 0;">BlazorSliders Test Page</h3>
+        <button @onclick="ToggleBottomPanel" style="padding: 8px 16px; background-color: #0e639c; color: white; border: none; border-radius: 4px; cursor: pointer; font-size: 14px;">
+            @(_showBottomPanel ? "Hide" : "Show") Bottom Panel
+        </button>
+    </div>
+
+    <div style="flex: 1; overflow: hidden; position: relative;">
+        <AbsolutePanel AutoResize="true">
+            <VerticalSliderPanel LeftPanelStartingWidth="300"
+                                 MinimumLeftPanelWidth="200"
+                                 MinimumRightPanelWidth="400">
+                <LeftChildContent>
+                    <div style="height: 100%; width: 100%; background-color: #ff4444; padding: 20px; overflow: auto; box-sizing: border-box;">
+                        <h2 style="color: white;">Left Panel (Red)</h2>
+                        <p style="color: white;">This should be visible with red background</p>
+                        @for (int i = 1; i <= 50; i++)
+                        {
+                            <p style="color: white;">Line @i</p>
+                        }
+                    </div>
+                </LeftChildContent>
+                <RightChildContent>
+                    <VerticalSliderPanel PanelPosition="PanelPosition.Right"
+                                         LeftPanelStartingWidth="800"
+                                         MinimumLeftPanelWidth="400"
+                                         MinimumRightPanelWidth="280">
+                        <LeftChildContent>
+                            <div style="height: 100%; width: 100%;">
+                                @if (_showBottomPanel)
+                                {
+                                    <HorizontalSliderPanel @key="@("horizontal-split")"
+                                                           PanelPosition="PanelPosition.Left"
+                                                           TopPanelHeight="300">
+                                        <TopChildContent>
+                                            <div style="height: 100%; width: 100%; background-color: #44ff44; padding: 20px; overflow: auto; box-sizing: border-box;">
+                                                <h2 style="color: black;">Top Panel (Green)</h2>
+                                                <p style="color: black;">This should be visible with green background</p>
+                                                @for (int i = 1; i <= 50; i++)
+                                                {
+                                                    <p style="color: black;">Top Line @i</p>
+                                                }
+                                            </div>
+                                        </TopChildContent>
+                                        <BottomChildContent>
+                                            <div style="height: 100%; width: 100%; background-color: #ff44ff; padding: 20px; overflow: auto; box-sizing: border-box;">
+                                                <h2 style="color: white;">Bottom Panel (Magenta)</h2>
+                                                <p style="color: white;">This should be visible with magenta background</p>
+                                                @for (int i = 1; i <= 50; i++)
+                                                {
+                                                    <p style="color: white;">Bottom Line @i</p>
+                                                }
+                                            </div>
+                                        </BottomChildContent>
+                                    </HorizontalSliderPanel>
+                                }
+                                else
+                                {
+                                    <div @key="@("single-panel")" style="height: 100%; width: 100%; background-color: #44ff44; padding: 20px; overflow: auto; box-sizing: border-box;">
+                                        <h2 style="color: black;">Center Panel (Green)</h2>
+                                        <p style="color: black;">This should be visible with green background - Bottom panel hidden</p>
+                                        @for (int i = 1; i <= 50; i++)
+                                        {
+                                            <p style="color: black;">Line @i</p>
+                                        }
+                                    </div>
+                                }
+                            </div>
+                        </LeftChildContent>
+                        <RightChildContent>
+                            <div style="height: 100%; width: 100%; background-color: #4444ff; padding: 20px; overflow: auto; box-sizing: border-box;">
+                                <h2 style="color: white;">Right Panel (Blue)</h2>
+                                <p style="color: white;">This should be visible with blue background</p>
+                                @for (int i = 1; i <= 50; i++)
+                                {
+                                    <p style="color: white;">Right Line @i</p>
+                                }
+                            </div>
+                        </RightChildContent>
+                    </VerticalSliderPanel>
+                </RightChildContent>
+            </VerticalSliderPanel>
+        </AbsolutePanel>
+    </div>
+</div>
+
+@code {
+    private bool _showBottomPanel = true;
+
+    private async Task ToggleBottomPanel()
+    {
+        _showBottomPanel = !_showBottomPanel;
+        await InvokeAsync(StateHasChanged);
+    }
+}


### PR DESCRIPTION
Added IDisposable implementation to HorizontalSliderPanel and VerticalSliderPanel to properly clean up parent panel references when components are destroyed during conditional rendering, fixing the bug where nested panels would alternately disappear when toggled due to stale parent-child references.